### PR TITLE
Update preprocess.py

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -52,13 +52,13 @@ def norm_data(args):
 				supported_voices))
 
 		path = os.path.join(args.base_dir, args.language, 'by_book', args.voice)
-		supported_readers = [e for e in os.listdir(path) if 'DS_Store' not in e]
+		supported_readers = [e for e in os.listdir(path) if os.path.isdir(os.path.join(path, e))]
 		if args.reader not in supported_readers:
 			raise ValueError('Please enter a valid reader for your language and voice settings! \n{}'.format(
 				supported_readers))
 
 		path = os.path.join(path, args.reader)
-		supported_books = [e for e in os.listdir(path) if e != '.DS_Store']
+		supported_books = [e for e in os.listdir(path) if os.path.isdir(os.path.join(path, e))]
 
 		if args.merge_books:
 			return [os.path.join(path, book) for book in supported_books]


### PR DESCRIPTION
This change addresses a small bug, primarily affecting `--merge_books True`. Some directories contain `Info.txt`, `.Info.txt`, `info.txt`, etc. The current code filters out `.DS_store` but tries to use everything else, including `Info.txt`, as a book when merging. In the current corpus anything that is a directory is a valid speaker or book, so this change filters based on that assumption.