### PR TITLE
TacoTrainingHelper bugfix

### DIFF
--- a/tacotron/models/helpers.py
+++ b/tacotron/models/helpers.py
@@ -110,10 +110,11 @@ class TacoTrainingHelper(Helper):
 				#GTA synthesis stop
 				finished = (time + 1 >= self._lengths)
 
-			if np.random.random() <= self._ratio:
-				next_inputs = self._targets[:, time, :] #Teacher-forcing: return true frame
-			else:
-				next_inputs = outputs[:, -self._output_dim:]
+			next_inputs = tf.cond(
+				tf.equal(tf.mod(time, int(1./self._ratio)), 0), 
+				lambda: self._targets[:, time, :], 
+				lambda: outputs[:,-self._output_dim:])
+                
 			#Update the finished state
 			next_state = state.replace(finished=tf.cast(tf.reshape(finished, [-1, 1]), tf.float32))
 			return (finished, next_inputs, next_state)


### PR DESCRIPTION
I found an error in TacoTrainingHelper implementation. Helper's method next_inputs is called only once, when model is created, to build a graph. It's not called on every frame. So you need to use TensorFlow's methods to decide if next input will be ground truth.