### PR TITLE
allow naming the logging directory

### DIFF
--- a/tacotron/train.py
+++ b/tacotron/train.py
@@ -196,7 +196,7 @@ def train(log_dir, args):
 def tacotron_train(args):
 	hparams.parse(args.hparams)
 	os.environ['TF_CPP_MIN_LOG_LEVEL'] = str(args.tf_log_level)
-	run_name = args.model
+	run_name = args.name or args.model
 	log_dir = os.path.join(args.base_dir, 'logs-{}'.format(run_name))
 	os.makedirs(log_dir, exist_ok=True)
 	infolog.init(os.path.join(log_dir, 'Terminal_train_log'), run_name)

--- a/train.py
+++ b/train.py
@@ -15,6 +15,7 @@ def main():
 	parser.add_argument('--checkpoint_interval', type=int, default=500,
 		help='Steps between writing checkpoints')
 	parser.add_argument('--tf_log_level', type=int, default=1, help='Tensorflow C++ log level.')
+	parser.add_argument('--name', help='Name of logging directory.')
 	args = parser.parse_args()
 
 	accepted_models = ['Tacotron', 'Wavenet']


### PR DESCRIPTION
This lets us name the logging directory, instead of forcing it to be named exactly the model we are running. So we can change hyperparams and keep the various versions of the model side-by-side. Also lets us compare loss histories and such in Tensorboard.