### PR TITLE
Fix audio trim default wrong arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Example M-AILABS:
 
 > python preprocess.py --dataset='M-AILABS' --language='en_US' --voice='female' --reader='mary_ann' --merge_books=False --book='northandsouth'
 
+or if you want to use all books for a single speaker:
+
+> python preprocess.py --dataset='M-AILABS' --language='en_US' --voice='female' --reader='mary_ann' --merge_books=True
+
 This should take no longer than a **few minutes.**
 
 # Training:

--- a/datasets/audio.py
+++ b/datasets/audio.py
@@ -48,18 +48,37 @@ def get_hop_size():
 		hop_size = int(hparams.frame_shift_ms / 1000 * hparams.sample_rate)
 	return hop_size
 
+def linearspectrogram(wav):
+	D = _stft(wav)
+	S = _amp_to_db(np.abs(D)) - hparams.ref_level_db
+
+	if hparams.signal_normalization:
+		return _normalize(S)
+	return S
+
 def melspectrogram(wav):
 	D = _stft(wav)
 	S = _amp_to_db(_linear_to_mel(np.abs(D))) - hparams.ref_level_db
 
-	if hparams.mel_normalization:
+	if hparams.signal_normalization:
 		return _normalize(S)
 	return S
+
+def inv_linear_spectrogram(linear_spectrogram):
+	'''Converts linear spectrogram to waveform using librosa'''
+	if hparams.signal_normalization:
+		D = _denormalize(linear_spectrogram)
+	else:
+		D = linear_spectrogram
+
+	S = _db_to_amp(D + hparams.ref_level_db) #Convert back to linear
+
+	return _griffin_lim(S ** hparams.power)
 	
 
 def inv_mel_spectrogram(mel_spectrogram):
 	'''Converts mel spectrogram to waveform using librosa'''
-	if hparams.mel_normalization:
+	if hparams.signal_normalization:
 		D = _denormalize(mel_spectrogram)
 	else:
 		D = mel_spectrogram

--- a/datasets/audio.py
+++ b/datasets/audio.py
@@ -33,7 +33,8 @@ def trim_silence(wav):
 
 	Useful for M-AILABS dataset if we choose to trim the extra 0.5 silences.
 	'''
-	return librosa.effects.trim(wav)[0]
+	return librosa.effects.trim(wav, frame_length=hparams.fft_size,
+		hop_length=get_hop_size())[0]
 
 def preemphasis(x):
 	return signal.lfilter([1, -hparams.preemphasis], [1], x)

--- a/datasets/preprocessor.py
+++ b/datasets/preprocessor.py
@@ -67,13 +67,13 @@ def _process_utterance(mel_dir, linear_dir, wav_dir, index, wav_path, text):
 			wav_path))
 		return None
 
-	#rescale wav
-	if hparams.rescale:
-		wav = wav / np.abs(wav).max() * hparams.rescaling_max
-
 	#M-AILABS extra silence specific
 	if hparams.trim_silence:
 		wav = audio.trim_silence(wav)
+
+	#rescale wav
+	if hparams.rescale:
+		wav = wav / np.abs(wav).max() * hparams.rescaling_max
 
 	#Mu-law quantize
 	if is_mulaw_quantize(hparams.input_type):

--- a/griffin_lim_synthesis_tool.ipynb
+++ b/griffin_lim_synthesis_tool.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "wav = inv_mel_spectrogram(mel_spectro.T) \n",
     "#save the wav under test_<folder>_<file>\n",
-    "save_wav(wav, os.path.join(out_dir, 'tests_{}.wav'.format(mel_file.replace('/', '_').replace('\\\\', '_'))))"
+    "save_wav(wav, os.path.join(out_dir, 'test_{}.wav'.format(mel_file.replace('/', '_').replace('\\\\', '_'))))"
    ]
   }
  ],

--- a/hparams.py
+++ b/hparams.py
@@ -1,19 +1,23 @@
-import tensorflow as tf 
-import numpy as np 
+import tensorflow as tf
+import numpy as np
 
 
 # Default hyperparameters
 hparams = tf.contrib.training.HParams(
 	# Comma-separated list of cleaners to run on text prior to training and eval. For non-English
-	# text, you may want to use "basic_cleaners" or "transliteration_cleaners" See TRAINING_DATA.md.
+	# text, you may want to use "basic_cleaners" or "transliteration_cleaners".
 	cleaners='english_cleaners',
 
 
 	#Audio
-	num_mels = 80, 
-	rescale = True, 
+	num_mels = 80,
+	num_freq = 513, #only used when adding linear spectrograms post processing network
+	rescale = True,
 	rescaling_max = 0.999,
 	trim_silence = True,
+	# Use LWS (https://github.com/Jonathan-LeRoux/lws) for STFT and phase reconstruction
+	# It's preferred to set True to use with https://github.com/r9y9/wavenet_vocoder
+	use_lws=False,
 
 	#Mel spectrogram
 	fft_size = 1024,
@@ -21,11 +25,11 @@ hparams = tf.contrib.training.HParams(
 	sample_rate = 22050, #22050 Hz (corresponding to ljspeech dataset)
 	frame_shift_ms = None,
 
-	#Mel spectrogram normalization/scaling and clipping
-	mel_normalization = True,
+	#Mel and Linear spectrograms normalization/scaling and clipping
+	signal_normalization = True,
 	allow_clipping_in_normalization = True, #Only relevant if mel_normalization = True
 	symmetric_mels = True, #Whether to scale the data to be symmetric around 0
-	max_abs_value = 4., #max absolute value of data. If symmetric, data will be [-max, max] else [0, max] 
+	max_abs_value = 4., #max absolute value of data. If symmetric, data will be [-max, max] else [0, max]
 
 	#Limits
 	min_level_db =- 100,
@@ -39,7 +43,7 @@ hparams = tf.contrib.training.HParams(
 
 
 	#Tacotron
-	outputs_per_step = 5, #number of frames to generate at each decoding step (speeds up computation and allows for higher batch size)
+	outputs_per_step = 1, #number of frames to generate at each decoding step (speeds up computation and allows for higher batch size)
 	stop_at_any = True, #Determines whether the decoder should stop when predicting <stop> to any frame or to all of them
 
 	embedding_dim = 512, #dimension of embedding space
@@ -49,15 +53,16 @@ hparams = tf.contrib.training.HParams(
 	enc_conv_channels = 512, #number of encoder convolutions filters for each layer
 	encoder_lstm_units = 256, #number of lstm units for each direction (forward and backward)
 
-	smoothing = False, #Whether to smooth the attention normalization function 
+	smoothing = False, #Whether to smooth the attention normalization function
 	attention_dim = 128, #dimension of attention space
 	attention_filters = 32, #number of attention convolution filters
 	attention_kernel = (31, ), #kernel size of attention convolution
+	cumulative_weights = True, #Whether to cumulate (sum) all previous attention weights or simply feed previous weights (Recommended: True)
 
 	prenet_layers = [256, 256], #number of layers and number of units of prenet
 	decoder_layers = 2, #number of decoder lstm layers
 	decoder_lstm_units = 1024, #number of decoder lstm units on each layer
-	max_iters = 1000, #Max decoder steps during inference (Just for safety from infinite loop cases)
+	max_iters = 2500, #Max decoder steps during inference (Just for safety from infinite loop cases)
 
 	postnet_num_layers = 5, #number of postnet convolutional layers
 	postnet_kernel_size = (5, ), #size of postnet convolution filters for each layer
@@ -67,36 +72,40 @@ hparams = tf.contrib.training.HParams(
 	impute_finished = False, #Whether to use loss mask for padded sequences
 	mask_finished = False, #Whether to mask alignments beyond the <stop_token> (False for debug, True for style)
 
+	predict_linear = False, #Whether to add a post-processing network to the Tacotron to predict linear spectrograms (True mode Not tested!!)
+
 
 	#Wavenet
 	# Input type:
-    # 1. raw [-1, 1]
-    # 2. mulaw [-1, 1]
-    # 3. mulaw-quantize [0, mu]
-    # If input_type is raw or mulaw, network assumes scalar input and
-    # discretized mixture of logistic distributions output, otherwise one-hot
-    # input and softmax output are assumed.
-    # **NOTE**: if you change the one of the two parameters below, you need to
-    # re-run preprocessing before training.
-    # **NOTE**: scaler input (raw or mulaw) is experimental. Use it your own risk.
-    input_type="mulaw-quantize",
-    quantize_channels=256,  # 65536 or 256
+	# 1. raw [-1, 1]
+	# 2. mulaw [-1, 1]
+	# 3. mulaw-quantize [0, mu]
+	# If input_type is raw or mulaw, network assumes scalar input and
+	# discretized mixture of logistic distributions output, otherwise one-hot
+	# input and softmax output are assumed.
+	# **NOTE**: if you change the one of the two parameters below, you need to
+	# re-run preprocessing before training.
+	# **NOTE**: scaler input (raw or mulaw) is experimental. Use it your own risk.
+	input_type="mulaw-quantize",
+	quantize_channels=256,  # 65536 or 256
 
-    silence_threshold=2,
+	silence_threshold=2,
 
-    # Mixture of logistic distributions:
-    log_scale_min=float(np.log(1e-14)),
+	# Mixture of logistic distributions:
+	log_scale_min=float(np.log(1e-14)),
 
-    #TODO model params
+	#TODO model params
 
 
 	#Tacotron Training
-	tacotron_batch_size = 64, #number of training samples on each training steps
+	tacotron_batch_size = 32, #number of training samples on each training steps
 	tacotron_reg_weight = 1e-6, #regularization weight (for l2 regularization)
+	tacotron_scale_regularization = True, #Whether to rescale regularization weight to adapt for outputs range (used when reg_weight is high and biasing the model)
 
 	tacotron_decay_learning_rate = True, #boolean, determines if the learning rate will follow an exponential decay
-	tacotron_decay_steps = 50000, #starting point for learning rate decay (and determines the decay slope)
-	tacotron_decay_rate = 0.4, #learning rate decay rate
+	tacotron_start_decay = 50000, #Step at which learning decay starts
+	tacotron_decay_steps = 50000, #starting point for learning rate decay (and determines the decay slope) (UNDER TEST)
+	tacotron_decay_rate = 0.4, #learning rate decay rate (UNDER TEST)
 	tacotron_initial_learning_rate = 1e-3, #starting learning rate
 	tacotron_final_learning_rate = 1e-5, #minimal learning rate
 
@@ -108,7 +117,7 @@ hparams = tf.contrib.training.HParams(
 	tacotron_dropout_rate = 0.5, #dropout rate for all convolutional layers + prenet
 
 	tacotron_teacher_forcing_ratio = 1., #Value from [0., 1.], 0.=0%, 1.=100%, determines the % of times we force next decoder inputs
-	
+
 
 	#Wavenet Training TODO
 
@@ -147,10 +156,10 @@ hparams = tf.contrib.training.HParams(
 	'it appears that oswald had only one caller in response to all of his fpcc activities,',
 	'he relied on the absence of the strychnia.',
 	'scoggins thought it was lighter.',
-	'''would, it is probable, have eventually overcome the reluctance of some of the prisoners at least, 
+	'''would, it is probable, have eventually overcome the reluctance of some of the prisoners at least,
 	and would have possessed so much moral dignity''',
-	'''the only purpose of this whole sentence is to evaluate the scalability of the model for very long sentences. 
-	This is not even a long sentence anymore, it has become an entire paragraph. 
+	'''the only purpose of this whole sentence is to evaluate the scalability of the model for very long sentences.
+	This is not even a long sentence anymore, it has become an entire paragraph.
 	Should I stop now? Let\'s add this last sentence in which we talk about nothing special.''',
 	'Thank you so much for your support!!'
 	]
@@ -158,6 +167,6 @@ hparams = tf.contrib.training.HParams(
 	)
 
 def hparams_debug_string():
-  values = hparams.values()
-  hp = ['  %s: %s' % (name, values[name]) for name in sorted(values) if name != 'sentences']
-return 'Hyperparameters:\n' + '\n'.join(hp)
+	values = hparams.values()
+	hp = ['  %s: %s' % (name, values[name]) for name in sorted(values) if name != 'sentences']
+	return 'Hyperparameters:\n' + '\n'.join(hp)

--- a/synthesize.py
+++ b/synthesize.py
@@ -13,8 +13,9 @@ def main():
 	parser.add_argument('--output_dir', default='output/', help='folder to contain synthesized mel spectrograms')
 	parser.add_argument('--mode', default='synthesis', help='mode of run: can be one of {}'.format(accepted_modes))
 	parser.add_argument('--GTA', default=True, help='Ground truth aligned synthesis, defaults to True, only considered in synthesis mode')
+	parser.add_argument('--text_list', default='', help='Text file contains list of texts to be synthesized. Valid if mode=eval')
 	args = parser.parse_args()
-	
+
 	accepted_models = ['Tacotron', 'Wavenet']
 
 	if args.model not in accepted_models:

--- a/tacotron/feeder.py
+++ b/tacotron/feeder.py
@@ -35,10 +35,11 @@ class Feeder(threading.Thread):
 
 		# Load metadata
 		self._mel_dir = os.path.join(os.path.dirname(metadata_filename), 'mels')
+		self._linear_dir = os.path.join(os.path.dirname(metadata_filename), 'linear')
 		with open(metadata_filename, encoding='utf-8') as f:
 			self._metadata = [line.strip().split('|') for line in f]
 			frame_shift_ms = hparams.hop_size / hparams.sample_rate
-			hours = sum([int(x[3]) for x in self._metadata]) * frame_shift_ms / (3600)
+			hours = sum([int(x[4]) for x in self._metadata]) * frame_shift_ms / (3600)
 			log('Loaded metadata for {} examples ({:.2f} hours)'.format(len(self._metadata), hours))
 
 		# Create placeholders for inputs and targets. Don't specify batch size because we want
@@ -48,16 +49,18 @@ class Feeder(threading.Thread):
 		tf.placeholder(tf.int32, shape=(None, ), name='input_lengths'),
 		tf.placeholder(tf.float32, shape=(None, None, hparams.num_mels), name='mel_targets'),
 		tf.placeholder(tf.float32, shape=(None, None), name='token_targets'),
+		tf.placeholder(tf.float32, shape=(None, None, hparams.num_freq), name='linear_targets'),
 		]
 
 		# Create queue for buffering data
-		queue = tf.FIFOQueue(8, [tf.int32, tf.int32, tf.float32, tf.float32], name='input_queue')
+		queue = tf.FIFOQueue(8, [tf.int32, tf.int32, tf.float32, tf.float32, tf.float32], name='input_queue')
 		self._enqueue_op = queue.enqueue(self._placeholders)
-		self.inputs, self.input_lengths, self.mel_targets, self.token_targets = queue.dequeue()
+		self.inputs, self.input_lengths, self.mel_targets, self.token_targets, self.linear_targets = queue.dequeue()
 		self.inputs.set_shape(self._placeholders[0].shape)
 		self.input_lengths.set_shape(self._placeholders[1].shape)
 		self.mel_targets.set_shape(self._placeholders[2].shape)
 		self.token_targets.set_shape(self._placeholders[3].shape)
+		self.linear_targets.set_shape(self._placeholders[4].shape)
 
 	def start_in_session(self, session):
 		self._session = session
@@ -91,7 +94,7 @@ class Feeder(threading.Thread):
 
 	def _get_next_example(self):
 		"""
-		Gets a single example (input, mel_target, token_target) from disk
+		Gets a single example (input, mel_target, token_target, linear_target, mel_length) from_ disk
 		"""
 		if self._offset >= len(self._metadata):
 			self._offset = 0
@@ -99,13 +102,14 @@ class Feeder(threading.Thread):
 		meta = self._metadata[self._offset]
 		self._offset += 1
 
-		text = meta[4]
+		text = meta[5]
 
 		input_data = np.asarray(text_to_sequence(text, self._cleaner_names), dtype=np.int32)
 		mel_target = np.load(os.path.join(self._mel_dir, meta[1]))
 		#Create parallel sequences containing zeros to represent a non finished sequence
 		token_target = np.asarray([0.] * len(mel_target))
-		return (input_data, mel_target, token_target, len(mel_target))
+		linear_target = np.load(os.path.join(self._linear_dir, meta[2]))
+		return (input_data, mel_target, token_target, linear_target, len(mel_target))
 
 
 def _prepare_batch(batch, outputs_per_step):
@@ -115,7 +119,8 @@ def _prepare_batch(batch, outputs_per_step):
 	mel_targets = _prepare_targets([x[1] for x in batch], outputs_per_step)
 	#Pad sequences with 1 to infer that the sequence is done
 	token_targets = _prepare_token_targets([x[2] for x in batch], outputs_per_step)
-	return (inputs, input_lengths, mel_targets, token_targets)
+	linear_targets = _prepare_targets([x[3] for x in batch], outputs_per_step)
+	return (inputs, input_lengths, mel_targets, token_targets, linear_targets)
 
 def _prepare_inputs(inputs):
 	max_len = max([len(x) for x in inputs])

--- a/tacotron/models/Architecture_wrappers.py
+++ b/tacotron/models/Architecture_wrappers.py
@@ -12,7 +12,7 @@ from tensorflow.python.util import nest
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import tensor_array_ops
 from tensorflow.python.framework import tensor_shape
-from tensorflow.contrib.seq2seq.python.ops.attention_wrapper import _compute_attention
+from tacotron.models.attention import _compute_attention
 
 _zero_state_tensors = rnn_cell_impl._zero_state_tensors
 
@@ -36,7 +36,7 @@ class TacotronEncoderCell(RNNCell):
 		self._convolutions = convolutional_layers
 		self._cell = lstm_layer
 
-	def __call__(self, inputs, input_lengths):
+	def __call__(self, inputs, input_lengths=None):
 		#Pass input sequence through a stack of convolutional layers
 		conv_output = self._convolutions(inputs)
 

--- a/tacotron/models/attention.py
+++ b/tacotron/models/attention.py
@@ -10,6 +10,33 @@ from tensorflow.python.ops import math_ops
 from hparams import hparams
 
 
+#From https://github.com/tensorflow/tensorflow/blob/r1.7/tensorflow/contrib/seq2seq/python/ops/attention_wrapper.py
+def _compute_attention(attention_mechanism, cell_output, attention_state,
+					   attention_layer):
+	"""Computes the attention and alignments for a given attention_mechanism."""
+	alignments, next_attention_state = attention_mechanism(
+		cell_output, state=attention_state)
+
+	# Reshape from [batch_size, memory_time] to [batch_size, 1, memory_time]
+	expanded_alignments = array_ops.expand_dims(alignments, 1)
+	# Context is the inner product of alignments and values along the
+	# memory time dimension.
+	# alignments shape is
+	#   [batch_size, 1, memory_time]
+	# attention_mechanism.values shape is
+	#   [batch_size, memory_time, memory_size]
+	# the batched matmul is over memory_time, so the output shape is
+	#   [batch_size, 1, memory_size].
+	# we then squeeze out the singleton dim.
+	context = math_ops.matmul(expanded_alignments, attention_mechanism.values)
+	context = array_ops.squeeze(context, [1])
+
+	if attention_layer is not None:
+		attention = attention_layer(array_ops.concat([cell_output, context], 1))
+	else:
+		attention = context
+
+	return attention, alignments, next_attention_state
 
 
 def _location_sensitive_score(W_query, W_fil, W_keys):
@@ -20,17 +47,17 @@ def _location_sensitive_score(W_query, W_fil, W_keys):
 	  vances in Neural Information Processing Systems, 2015, pp.
 	  577–585.
 
-    #############################################################################
-              hybrid attention (content-based + location-based)
-        				       f = F * α_{i-1}
-       energy = dot(v_a, tanh(W_keys(h_enc) + W_query(h_dec) + W_fil(f) + b_a))
-    #############################################################################
+	#############################################################################
+			  hybrid attention (content-based + location-based)
+							   f = F * α_{i-1}
+	   energy = dot(v_a, tanh(W_keys(h_enc) + W_query(h_dec) + W_fil(f) + b_a))
+	#############################################################################
 
-    Args:
+	Args:
 		W_query: Tensor, shape '[batch_size, 1, attention_dim]' to compare to location features.
 		W_location: processed previous alignments into location features, shape '[batch_size, max_time, attention_dim]'
 		W_keys: Tensor, shape '[batch_size, max_time, attention_dim]', typically the encoder outputs.
-    Returns:
+	Returns:
 		A '[batch_size, max_time]' attention score (energy)
 	"""
 	# Get the number of hidden units from the trailing dimension of keys
@@ -38,7 +65,8 @@ def _location_sensitive_score(W_query, W_fil, W_keys):
 	num_units = W_keys.shape[-1].value or array_ops.shape(W_keys)[-1]
 
 	v_a = tf.get_variable(
-		'attention_variable', shape=[num_units], dtype=dtype)
+		'attention_variable', shape=[num_units], dtype=dtype,
+		initializer=tf.contrib.layers.xavier_initializer())
 	b_a = tf.get_variable(
 		'attention_bias', shape=[num_units], dtype=dtype,
 		initializer=tf.zeros_initializer())
@@ -54,17 +82,17 @@ def _smoothing_normalization(e):
 	  577–585.
 
 	############################################################################
-    				   	Smoothing normalization function
-    		  	a_{i, j} = sigmoid(e_{i, j}) / sum_j(sigmoid(e_{i, j}))
-  	############################################################################
+						Smoothing normalization function
+				a_{i, j} = sigmoid(e_{i, j}) / sum_j(sigmoid(e_{i, j}))
+	############################################################################
 
-  	Args:
-  		e: matrix [batch_size, max_time(memory_time)]: expected to be energy (score)
-  			values of an attention mechanism
-  	Returns:
-  		matrix [batch_size, max_time]: [0, 1] normalized alignments with possible
-  			attendance to multiple memory time steps.
-  	"""
+	Args:
+		e: matrix [batch_size, max_time(memory_time)]: expected to be energy (score)
+			values of an attention mechanism
+	Returns:
+		matrix [batch_size, max_time]: [0, 1] normalized alignments with possible
+			attendance to multiple memory time steps.
+	"""
 	return tf.nn.sigmoid(e) / tf.reduce_sum(tf.nn.sigmoid(e), axis=-1, keepdims=True)
 
 
@@ -75,8 +103,8 @@ class LocationSensitiveAttention(BahdanauAttention):
 	"D. Bahdanau, K. Cho, and Y. Bengio, “Neural machine transla-
   tion by jointly learning to align and translate,” in Proceedings
   of ICLR, 2015."
-  	to use previous alignments as additional location features.
-  	
+	to use previous alignments as additional location features.
+	
 	This attention is described in:
 	J. K. Chorowski, D. Bahdanau, D. Serdyuk, K. Cho, and Y. Ben-
   gio, “Attention-based models for speech recognition,” in Ad-
@@ -90,6 +118,7 @@ class LocationSensitiveAttention(BahdanauAttention):
 				 mask_encoder=True,
 				 memory_sequence_length=None,
 				 smoothing=False,
+				 cumulate_weights=True,
 				 name='LocationSensitiveAttention'):
 		"""Construct the Attention mechanism.
 		Args:
@@ -134,6 +163,7 @@ class LocationSensitiveAttention(BahdanauAttention):
 			name='location_features_convolution')
 		self.location_layer = tf.layers.Dense(units=num_units, use_bias=False, 
 			dtype=tf.float32, name='location_features_layer')
+		self._cumulate = cumulate_weights
 
 	def __call__(self, query, state):
 		"""Score the query based on the keys and values.
@@ -171,5 +201,9 @@ class LocationSensitiveAttention(BahdanauAttention):
 		alignments = self._probability_fn(energy, previous_alignments)
 
 		# Cumulate alignments
-		next_state = alignments + previous_alignments
+		if self._cumulate:
+			next_state = alignments + previous_alignments
+		else:
+			next_state = alignments
+			
 		return alignments, next_state

--- a/tacotron/models/modules.py
+++ b/tacotron/models/modules.py
@@ -113,8 +113,8 @@ class Prenet:
 				dense = tf.layers.dense(x, units=size, activation=self.activation,
 					name='dense_{}'.format(i + 1))
 				#The paper discussed introducing diversity in generation at inference time
-				#by using a dropout of 0.5 only in prenet layers.
-				x = tf.layers.dropout(dense, rate=self.drop_rate, training=self.is_training,
+				#by using a dropout of 0.5 only in prenet layers (in both training and inference).
+				x = tf.layers.dropout(dense, rate=self.drop_rate, training=True,
 					name='dropout_{}'.format(i + 1) + self.scope)
 		return x
 

--- a/tacotron/models/tacotron.py
+++ b/tacotron/models/tacotron.py
@@ -7,13 +7,7 @@ from tacotron.models.zoneout_LSTM import ZoneoutLSTMCell
 from tensorflow.contrib.seq2seq import dynamic_decode
 from tacotron.models.Architecture_wrappers import TacotronEncoderCell, TacotronDecoderCell
 from tacotron.models.custom_decoder import CustomDecoder
-
-if int(tf.__version__.replace('.', '')) < 160:
-	log('using old attention Tensorflow structure (1.5.0 and earlier)')
-	from tacotron.models.attention_old import LocationSensitiveAttention
-else:
-	log('using new attention Tensorflow structure (1.6.0 and later)')
-	from tacotron.models.attention import LocationSensitiveAttention
+from tacotron.models.attention import LocationSensitiveAttention
 
 
 
@@ -23,7 +17,7 @@ class Tacotron():
 	def __init__(self, hparams):
 		self._hparams = hparams
 
-	def initialize(self, inputs, input_lengths, mel_targets=None, stop_token_targets=None, gta=False):
+	def initialize(self, inputs, input_lengths, mel_targets=None, stop_token_targets=None, linear_targets=None, gta=False):
 		"""
 		Initializes the model for inference
 
@@ -42,11 +36,17 @@ class Tacotron():
 			raise ValueError('no mel targets were provided but token_targets were given')
 		if mel_targets is not None and stop_token_targets is None and not gta:
 			raise ValueError('Mel targets are provided without corresponding token_targets')
+		if gta==False and self._hparams.predict_linear==True and linear_targets is None:
+			raise ValueError('Model is set to use post processing to predict linear spectrograms in training but no linear targets given!')
+		if gta and linear_targets is not None:
+			raise ValueError('Linear spectrogram prediction is not supported in GTA mode!')
 
 		with tf.variable_scope('inference') as scope:
 			is_training = mel_targets is not None and not gta
 			batch_size = tf.shape(inputs)[0]
 			hp = self._hparams
+			#GTA is only used for predicting mels to train Wavenet vocoder, so we ommit post processing when doing GTA synthesis
+			post_condition = hp.predict_linear and not gta
 
 			# Embeddings ==> [batch_size, sequence_length, embedding_dim]
 			embedding_table = tf.get_variable(
@@ -72,7 +72,8 @@ class Tacotron():
 			prenet = Prenet(is_training, layer_sizes=hp.prenet_layers, scope='decoder_prenet')
 			#Attention Mechanism
 			attention_mechanism = LocationSensitiveAttention(hp.attention_dim, encoder_outputs,
-				mask_encoder=hp.mask_encoder, memory_sequence_length=input_lengths, smoothing=hp.smoothing)
+				mask_encoder=hp.mask_encoder, memory_sequence_length=input_lengths, smoothing=hp.smoothing, 
+				cumulate_weights=hp.cumulative_weights)
 			#Decoder LSTM Cells
 			decoder_lstm = DecoderRNN(is_training, layers=hp.decoder_layers,
 				size=hp.decoder_lstm_units, zoneout=hp.tacotron_zoneout_rate, scope='decoder_lstm')
@@ -135,6 +136,19 @@ class Tacotron():
 			#Compute the mel spectrogram
 			mel_outputs = decoder_output + projected_residual
 
+
+			if post_condition:
+				#Based on https://github.com/keithito/tacotron/blob/tacotron2-work-in-progress/models/tacotron.py
+				#Post-processing Network to map mels to linear spectrograms using same architecture as the encoder
+				post_processing_cell = TacotronEncoderCell(
+				EncoderConvolutions(is_training, kernel_size=hp.enc_conv_kernel_size,
+					channels=hp.enc_conv_channels, scope='post_processing_convolutions'),
+				EncoderRNN(is_training, size=hp.encoder_lstm_units,
+					zoneout=hp.tacotron_zoneout_rate, scope='post_processing_LSTM'))
+
+				expand_outputs = post_processing_cell(mel_outputs)
+				linear_outputs = FrameProjection(hp.num_freq, scope='post_processing_projection')(expand_outputs)
+
 			#Grab alignments from the final decoder state
 			alignments = tf.transpose(final_decoder_state.alignment_history.stack(), [1, 2, 0])
 
@@ -145,8 +159,11 @@ class Tacotron():
 			self.stop_token_prediction = stop_token_prediction
 			self.stop_token_targets = stop_token_targets
 			self.mel_outputs = mel_outputs
+			if post_condition:
+				self.linear_outputs = linear_outputs
+				self.linear_targets = linear_targets
 			self.mel_targets = mel_targets
-			log('Initialized Tacotron model. Dimensions: ')
+			log('Initialized Tacotron model. Dimensions (? = dynamic shape): ')
 			log('  embedding:                {}'.format(embedded_inputs.shape))
 			log('  enc conv out:             {}'.format(enc_conv_output_shape))
 			log('  encoder out:              {}'.format(encoder_outputs.shape))
@@ -154,6 +171,8 @@ class Tacotron():
 			log('  residual out:             {}'.format(residual.shape))
 			log('  projected residual out:   {}'.format(projected_residual.shape))
 			log('  mel out:                  {}'.format(mel_outputs.shape))
+			if post_condition:
+				log('  linear out:               {}'.format(linear_outputs.shape))
 			log('  <stop_token> out:         {}'.format(stop_token_prediction.shape))
 
 
@@ -171,19 +190,36 @@ class Tacotron():
 				labels=self.stop_token_targets,
 				logits=self.stop_token_prediction))
 
+			if hp.predict_linear:
+				#Compute linear loss
+				#From https://github.com/keithito/tacotron/blob/tacotron2-work-in-progress/models/tacotron.py
+				#Prioritize loss for frequencies under 2000 Hz.
+				l1 = tf.abs(self.linear_targets - self.linear_outputs)
+				n_priority_freq = int(2000 / (hp.sample_rate * 0.5) * hp.num_mels)
+				linear_loss = 0.5 * tf.reduce_mean(l1) + 0.5 * tf.reduce_mean(l1[:,:,0:n_priority_freq])
+			else:
+				linear_loss = 0.
+
+			# Compute the regularization weight
+			if hp.tacotron_scale_regularization:
+				reg_weight_scaler = 1. / (2 * hp.max_abs_value) if hp.symmetric_mels else 1. / (hp.max_abs_value)
+				reg_weight = hp.tacotron_reg_weight * reg_weight_scaler
+			else:
+				reg_weight = hp.tacotron_reg_weight
+
 			# Get all trainable variables
 			all_vars = tf.trainable_variables()
-			# Compute the regularization term
 			regularization = tf.add_n([tf.nn.l2_loss(v) for v in all_vars
-				if not('bias' in v.name or 'Bias' in v.name)]) * hp.tacotron_reg_weight
+				if not('bias' in v.name or 'Bias' in v.name)]) * reg_weight
 
 			# Compute final loss term
 			self.before_loss = before
 			self.after_loss = after
 			self.stop_token_loss = stop_token_loss
 			self.regularization_loss = regularization
+			self.linear_loss = linear_loss
 
-			self.loss = self.before_loss + self.after_loss + self.stop_token_loss + self.regularization_loss 
+			self.loss = self.before_loss + self.after_loss + self.stop_token_loss + self.regularization_loss + self.linear_loss
 
 	def add_optimizer(self, global_step):
 		'''Adds optimizer. Sets "gradients" and "optimize" fields. add_loss must have been called.
@@ -204,21 +240,38 @@ class Tacotron():
 				hp.tacotron_adam_beta2, hp.tacotron_adam_epsilon)
 			gradients, variables = zip(*optimizer.compute_gradients(self.loss))
 			self.gradients = gradients
+			#Just for causion
+			#https://github.com/Rayhane-mamah/Tacotron-2/issues/11
+			clipped_gradients, _ = tf.clip_by_global_norm(gradients, 0.5)
 
 			# Add dependency on UPDATE_OPS; otherwise batchnorm won't work correctly. See:
 			# https://github.com/tensorflow/tensorflow/issues/1122
 			with tf.control_dependencies(tf.get_collection(tf.GraphKeys.UPDATE_OPS)):
-				self.optimize = optimizer.apply_gradients(zip(gradients, variables),
+				self.optimize = optimizer.apply_gradients(zip(clipped_gradients, variables),
 					global_step=global_step)
 
 	def _learning_rate_decay(self, init_lr, global_step):
-		# Exponential decay
-		# We won't drop learning rate below 10e-5
+		#################################################################
+		# Narrow Exponential Decay:
+
+		# Phase 1: lr = 1e-3
+		# We only start learning rate decay after 50k steps
+
+		# Phase 2: lr in ]1e-3, 1e-5[
+		# decay reach minimal value at step 300k
+
+		# Phase 3: lr = 1e-5
+		# clip by minimal learning rate value (step > 300k)
+		#################################################################
 		hp = self._hparams
-		step = tf.cast(global_step + 1, dtype=tf.float32)
+
+		#Compute natural exponential decay
 		lr = tf.train.exponential_decay(init_lr, 
-			global_step - self.decay_steps + 1, 
+			global_step - hp.tacotron_start_decay, #lr = 1e-3 at step 50k
 			self.decay_steps, 
-			self.decay_rate,
+			self.decay_rate, #lr = 1e-5 around step 300k
 			name='exponential_decay')
-		return tf.maximum(hp.tacotron_final_learning_rate, lr)
+
+
+		#clip learning rate by max and min values (initial and final values)
+		return tf.minimum(tf.maximum(lr, hp.tacotron_final_learning_rate), init_lr)

--- a/tacotron/synthesize.py
+++ b/tacotron/synthesize.py
@@ -3,12 +3,12 @@ import os
 import re
 from hparams import hparams, hparams_debug_string
 from tacotron.synthesizer import Synthesizer
-import tensorflow as tf 
+import tensorflow as tf
 import time
 from tqdm import tqdm
 
 
-def run_eval(args, checkpoint_path, output_dir):
+def run_eval(args, checkpoint_path, output_dir, sentences):
 	print(hparams_debug_string())
 	synth = Synthesizer()
 	synth.load(checkpoint_path)
@@ -22,7 +22,7 @@ def run_eval(args, checkpoint_path, output_dir):
 	os.makedirs(os.path.join(log_dir, 'plots'), exist_ok=True)
 
 	with open(os.path.join(eval_dir, 'map.txt'), 'w') as file:
-		for i, text in enumerate(tqdm(hparams.sentences)):
+		for i, text in enumerate(tqdm(sentences)):
 			start = time.time()
 			mel_filename = synth.synthesize(text, i+1, eval_dir, log_dir, None)
 
@@ -37,7 +37,7 @@ def run_synthesis(args, checkpoint_path, output_dir):
 	with open(metadata_filename, encoding='utf-8') as f:
 		metadata = [line.strip().split('|') for line in f]
 		frame_shift_ms = hparams.hop_size / hparams.sample_rate
-		hours = sum([int(x[3]) for x in metadata]) * frame_shift_ms / (3600)
+		hours = sum([int(x[4]) for x in metadata]) * frame_shift_ms / (3600)
 		print('Loaded metadata for {} examples ({:.2f} hours)'.format(len(metadata), hours))
 
 	if args.GTA==True:
@@ -50,19 +50,26 @@ def run_synthesis(args, checkpoint_path, output_dir):
 
 	print('starting synthesis')
 	mel_dir = os.path.join(args.input_dir, 'mels')
+	wav_dir = os.path.join(args.input_dir, 'audio')
 	with open(os.path.join(synth_dir, 'map.txt'), 'w') as file:
 		for i, meta in enumerate(tqdm(metadata)):
-			text = meta[4]
+			text = meta[5]
 			mel_filename = os.path.join(mel_dir, meta[1])
+			wav_filename = os.path.join(wav_dir, meta[0])
 			mel_output_filename = synth.synthesize(text, i+1, synth_dir, None, mel_filename)
 
-			file.write('{}|{}|{}\n'.format(text, mel_filename, mel_output_filename))
+			file.write('{}|{}|{}|{}\n'.format(text, mel_filename, mel_output_filename, wav_filename))
 	print('synthesized mel spectrograms at {}'.format(synth_dir))
 
 def tacotron_synthesize(args):
 	hparams.parse(args.hparams)
 	os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 	output_dir = 'tacotron_' + args.output_dir
+	if args.text_list != '':
+		with open(args.text_list, 'rb') as f:
+			sentences = list(map(lambda l:l.decode("utf-8")[:-1], f.readlines()))
+	else:
+		sentences = hparams.sentences
 
 	try:
 		checkpoint_path = tf.train.get_checkpoint_state(args.checkpoint).model_checkpoint_path
@@ -71,6 +78,6 @@ def tacotron_synthesize(args):
 		raise AssertionError('Cannot restore checkpoint: {}, did you train a model?'.format(args.checkpoint))
 
 	if args.mode == 'eval':
-		run_eval(args, checkpoint_path, output_dir)
+		run_eval(args, checkpoint_path, output_dir, sentences)
 	else:
 		run_synthesis(args, checkpoint_path, output_dir)

--- a/tacotron/synthesizer.py
+++ b/tacotron/synthesizer.py
@@ -44,26 +44,36 @@ class Synthesizer:
 		if self.gta:
 			feed_dict[self.model.mel_targets] = np.load(mel_filename).reshape(1, -1, 80)
 
-		mels, alignment = self.session.run([self.mel_outputs, self.alignment], feed_dict=feed_dict)
+		if self.gta or not hparams.predict_linear:
+			mels, alignment = self.session.run([self.mel_outputs, self.alignment], feed_dict=feed_dict)
 
-		mels = mels.reshape(-1, 80) #Thanks to @imdatsolak for pointing this out
+		else:
+			linear, mels, alignment = self.session.run([self.linear_outputs, self.mel_outputs, self.alignment], feed_dict=feed_dict)
+			linear = linear.reshape(-1, hparams.num_freq)
+
+		mels = mels.reshape(-1, hparams.num_mels) #Thanks to @imdatsolak for pointing this out
 
 		# Write the spectrogram to disk
 		# Note: outputs mel-spectrogram files and target ones have same names, just different folders
-		mel_filename = os.path.join(out_dir, 'ljspeech-mel-{:05d}.npy'.format(index))
+		mel_filename = os.path.join(out_dir, 'speech-mel-{:05d}.npy'.format(index))
 		np.save(mel_filename, mels, allow_pickle=False)
 
 		if log_dir is not None:
-			#save wav
+			#save wav (mel -> wav)
 			wav = audio.inv_mel_spectrogram(mels.T)
-			audio.save_wav(wav, os.path.join(log_dir, 'wavs/ljspeech-wav-{:05d}.wav'.format(index)))
+			audio.save_wav(wav, os.path.join(log_dir, 'wavs/speech-wav-{:05d}-mel.wav'.format(index)))
+
+			if hparams.predict_linear:
+				#save wav (linear -> wav)
+				wav = audio.inv_linear_spectrogram(linear.T)
+				audio.save_wav(wav, os.path.join(log_dir, 'wavs/speech-wav-{:05d}-linear.wav'.format(index)))
 
 			#save alignments
-			plot.plot_alignment(alignment, os.path.join(log_dir, 'plots/ljspeech-alignment-{:05d}.png'.format(index)),
+			plot.plot_alignment(alignment, os.path.join(log_dir, 'plots/speech-alignment-{:05d}.png'.format(index)),
 				info='{}'.format(text), split_title=True)
 
 			#save mel spectrogram plot
-			plot.plot_spectrogram(mels, os.path.join(log_dir, 'plots/ljspeech-mel-{:05d}.png'.format(index)),
+			plot.plot_spectrogram(mels, os.path.join(log_dir, 'plots/speech-mel-{:05d}.png'.format(index)),
 				info='{}'.format(text), split_title=True)
 
 		return mel_filename

--- a/tacotron/utils/cleaners.py
+++ b/tacotron/utils/cleaners.py
@@ -52,6 +52,8 @@ def expand_numbers(text):
 
 
 def lowercase(text):
+  '''lowercase input tokens.
+  '''
   return text.lower()
 
 
@@ -81,7 +83,6 @@ def transliteration_cleaners(text):
 def english_cleaners(text):
   '''Pipeline for English text, including number and abbreviation expansion.'''
   text = convert_to_ascii(text)
-  text = lowercase(text)
   text = expand_numbers(text)
   text = expand_abbreviations(text)
   text = collapse_whitespace(text)

--- a/train.py
+++ b/train.py
@@ -8,6 +8,7 @@ def main():
 	parser.add_argument('--hparams', default='',
 		help='Hyperparameter overrides as a comma-separated list of name=value pairs')
 	parser.add_argument('--input', default='training_data/train.txt')
+	parser.add_argument('--name', help='Name of logging directory.')
 	parser.add_argument('--model', default='Tacotron')
 	parser.add_argument('--restore', type=bool, default=True, help='Set this to False to do a fresh training')
 	parser.add_argument('--summary_interval', type=int, default=100,


### PR DESCRIPTION
Fix `librosa.effects.trim` method with wrong default arguments of `frame_length` and `hop_length` corresponding to hyper parameters `fft_size` and `hop_size`. This fix improves the training speed to convergence.