### PR TITLE
Rounding down fix

### DIFF
--- a/tacotron/feeder.py
+++ b/tacotron/feeder.py
@@ -44,7 +44,7 @@ class Feeder:
 			test_size=test_size, random_state=hparams.tacotron_data_random_state)
 
 		#Make sure test_indices is a multiple of batch_size else round up
-		len_test_indices = self._round_up(len(test_indices), hparams.tacotron_batch_size) - hparams.tacotron_batch_size
+		len_test_indices = self._round_down(len(test_indices), hparams.tacotron_batch_size)
 		extra_test = test_indices[len_test_indices:]
 		test_indices = test_indices[:len_test_indices]
 		train_indices = np.concatenate([train_indices, extra_test])
@@ -225,6 +225,10 @@ class Feeder:
 	def _pad_token_target(self, t, length):
 		return np.pad(t, (0, length - t.shape[0]), mode='constant', constant_values=self._token_pad)
 
+	def _round_down(self, x, multiple):
+		remainder = x % multiple
+		return x if remainder == 0 else x - remainder
+		
 	def _round_up(self, x, multiple):
 		remainder = x % multiple
 		return x if remainder == 0 else x + multiple - remainder


### PR DESCRIPTION
If test_indices is divisible by the batch size, one batch size too much is subtracted.

(edited this directly on the github page, so I hope the tab indentation is correct)