### PR TITLE
Add preemphasis on linear spectrograms

### DIFF
--- a/datasets/audio.py
+++ b/datasets/audio.py
@@ -61,7 +61,7 @@ def linearspectrogram(wav, hparams):
 	return S
 
 def melspectrogram(wav, hparams):
-	D = _stft(wav, hparams)
+	D = _stft(preemphasis(wav, hparams.preemphasis), hparams)
 	S = _amp_to_db(_linear_to_mel(np.abs(D), hparams), hparams) - hparams.ref_level_db
 
 	if hparams.signal_normalization:
@@ -99,9 +99,9 @@ def inv_mel_spectrogram(mel_spectrogram, hparams):
 		processor = _lws_processor(hparams)
 		D = processor.run_lws(S.astype(np.float64).T ** hparams.power)
 		y = processor.istft(D).astype(np.float32)
-		return y
+		return inv_preemphasis(y)
 	else:
-		return _griffin_lim(S ** hparams.power, hparams)
+		return inv_preemphasis(_griffin_lim(S ** hparams.power, hparams), hparams.preemphasis)
 
 def _lws_processor(hparams):
 	import lws

--- a/datasets/audio.py
+++ b/datasets/audio.py
@@ -17,6 +17,12 @@ def save_wav(wav, path, sr):
 def save_wavenet_wav(wav, path, sr):
 	librosa.output.write_wav(path, wav, sr=sr)
 
+def preemphasis(wav, k):
+	return signal.lfilter([1, -k], [1], wav)
+
+def inv_preemphasis(wav, k):
+	return signal.lfilter([1], [1, -k], wav)
+
 #From https://github.com/r9y9/wavenet_vocoder/blob/master/audio.py
 def start_and_end_indices(quantized, silence_threshold=2):
 	for start in range(quantized.size):
@@ -47,7 +53,7 @@ def get_hop_size(hparams):
 	return hop_size
 
 def linearspectrogram(wav, hparams):
-	D = _stft(wav, hparams)
+	D = _stft(preemphasis(wav, hparams.preemphasis), hparams)
 	S = _amp_to_db(np.abs(D), hparams) - hparams.ref_level_db
 
 	if hparams.signal_normalization:
@@ -75,9 +81,9 @@ def inv_linear_spectrogram(linear_spectrogram, hparams):
 		processor = _lws_processor(hparams)
 		D = processor.run_lws(S.astype(np.float64).T ** hparams.power)
 		y = processor.istft(D).astype(np.float32)
-		return y
+		return inv_preemphasis(y, hparams.preemphasis)
 	else:
-		return _griffin_lim(S ** hparams.power, hparams)
+		return inv_preemphasis(_griffin_lim(S ** hparams.power, hparams), hparams.preemphasis)
 
 
 def inv_mel_spectrogram(mel_spectrogram, hparams):

--- a/hparams.py
+++ b/hparams.py
@@ -29,6 +29,7 @@ hparams = tf.contrib.training.HParams(
 	win_size = 1200, #For 22050Hz, 1100 ~= 50 ms (If None, win_size = n_fft)
 	sample_rate = 24000, #22050 Hz (corresponding to ljspeech dataset)
 	frame_shift_ms = None,
+	preemphasis = 0.97, # preemphasis coefficient
 
 	#M-AILABS (and other datasets) trim params
 	trim_fft_size = 512,


### PR DESCRIPTION
Pre-emphasis plays an important role on audio signal processing and would generate good results for G&L vocoder. See https://github.com/Rayhane-mamah/Tacotron-2/issues/157