### PR TITLE
Fix not-imported platform module.

### DIFF
--- a/tacotron/synthesizer.py
+++ b/tacotron/synthesizer.py
@@ -1,6 +1,7 @@
 import os
 import wave
 from datetime import datetime
+import platform
 
 import numpy as np
 import pyaudio


### PR DESCRIPTION
Fixes not-imported `Platform` module that results in error when `live` mode is used. 
Used in [tacotron/synthesizer.py:172](https://github.com/Rayhane-mamah/Tacotron-2/blob/master/tacotron/synthesizer.py#L172)