### PR TITLE
Fix synthesis when synthesis batch size > 1

### DIFF
--- a/tacotron/synthesizer.py
+++ b/tacotron/synthesizer.py
@@ -157,7 +157,7 @@ class Synthesizer:
 			linears = np.clip(linears, T2_output_range[0], T2_output_range[1])
 			assert len(mels) == len(linears) == len(texts)
 
-		mels = np.clip(mels, T2_output_range[0], T2_output_range[1])
+		mels = [np.clip(m, T2_output_range[0], T2_output_range[1]) for m in mels]
 
 		if basenames is None:
 			#Generate wav and read it


### PR DESCRIPTION
`tacotron/synthesizer.py` breaks if you are using a synthesis batch size greater than 1. This is because `np.clip()` is called on a list of mel spectrograms, but it expected an array-like that it can convert to an ndarray. It can't do this, so it throws an error. 

Making `np.clip()` applied to each individual mel spectrogram in the list prevents this issue.