### PR TITLE
Fixed error with certain datasets and UTF-8

### DIFF
--- a/datasets/preprocessor.py
+++ b/datasets/preprocessor.py
@@ -30,7 +30,7 @@ def build_from_path(hparams, input_dirs, mel_dir, linear_dir, wav_dir, n_jobs=12
 	futures = []
 	index = 1
 	for input_dir in input_dirs:
-		with open(os.path.join(input_dir, 'metadata.csv'), encoding='utf-8') as f:
+		with open(os.path.join(input_dir, 'metadata.csv'), encoding='utf-8', errors='ignore') as f:
 			for line in f:
 				parts = line.strip().split('|')
 				basename = parts[0]


### PR DESCRIPTION
In essence, this fixes the error that if you were to have a dataset with non UTF-8 characters; it would simply crash the program. 